### PR TITLE
PR#05:L-02: Insufficient Input Validation Enables Creation of Empty …

### DIFF
--- a/contracts/Lockx.sol
+++ b/contracts/Lockx.sol
@@ -210,6 +210,11 @@ contract Lockx is ERC721, Ownable, Withdrawals, IERC5192 {
             nftContracts.length != nftTokenIds.length
         ) revert ArrayLengthMismatch();
         if (msg.value != amountETH) revert EthValueMismatch();
+        
+        // Prevent empty lockbox creation - at least one asset must be provided
+        if (amountETH == 0 && tokenAddresses.length == 0 && nftContracts.length == 0) {
+            revert ZeroAmount();
+        }
 
         // 2) Effects
         uint256 tokenId = _nextId++;


### PR DESCRIPTION
- Added check to ensure at least one asset is provided in createLockboxWithBatch