### PR TITLE
PR#07:L-04: Prevent orphaned ETH from direct transfers

### DIFF
--- a/contracts/Lockx.sol
+++ b/contracts/Lockx.sol
@@ -43,6 +43,7 @@ contract Lockx is ERC721, Ownable, Withdrawals, IERC5192 {
     error TransfersDisabled();
     error UseDepositETH();
     error FallbackNotAllowed();
+    error DirectETHTransferNotAllowed();
     error SelfMintOnly();
     error LockboxNotEmpty();
 
@@ -462,11 +463,15 @@ contract Lockx is ERC721, Ownable, Withdrawals, IERC5192 {
     /* ───────────────────────── Fallback handlers ───────────────────────── */
     
     /**
-     * @notice Receive ETH from swaps and other legitimate sources.
-     * @dev Empty by design - accounting handled by calling functions.
+     * @notice Receive ETH only from allowed routers.
+     * @dev Prevents orphaned ETH from direct transfers.
+     *      Legitimate ETH comes through deposit functions routers.
      */
     receive() external payable {
-        // Accept ETH transfers - accounting handled by caller
+        // Only accept ETH from allowed routers
+        if (!_isAllowedRouter(msg.sender)) {
+            revert DirectETHTransferNotAllowed();
+        }
     }
     
     fallback() external {

--- a/contracts/Withdrawals.sol
+++ b/contracts/Withdrawals.sol
@@ -641,7 +641,7 @@ abstract contract Withdrawals is Deposits {
      * @param router The router address to check.
      * @return bool True if the router is allowed.
      */
-    function _isAllowedRouter(address router) private pure returns (bool) {
+    function _isAllowedRouter(address router) internal pure returns (bool) {
         return
             // Uniswap Universal Router (standard - supports V2/V3/V4)
             router == 0x3fC91A3afd70395Cd496C647d5a6CC9D4B2b7FAD ||


### PR DESCRIPTION
- Added DirectETHTransferNotAllowed() error
- Modified receive() function to only accept ETH from whitelisted routers
- Changed _isAllowedRouter() visibility in Withdrawals contract from private to internal for cross-contract access