### PR TITLE
PR#8:L-05: Prevent misleading events on duplicate key rotation

### DIFF
--- a/contracts/Lockx.sol
+++ b/contracts/Lockx.sol
@@ -45,6 +45,7 @@ contract Lockx is ERC721, Ownable, Withdrawals, IERC5192 {
     error FallbackNotAllowed();
     error SelfMintOnly();
     error LockboxNotEmpty();
+    error DuplicateKey();
 
 
     /* ───────────────────────── Metadata storage ────────────────────────── */
@@ -333,6 +334,9 @@ contract Lockx is ERC721, Ownable, Withdrawals, IERC5192 {
     ) external nonReentrant {
         _requireOwnsLockbox(tokenId);
         if (block.timestamp > signatureExpiry) revert SignatureExpired();
+        
+        // Check that the new key is different from the current key
+        if (_getActiveLockboxPublicKey(tokenId) == newPublicKey) revert DuplicateKey();
 
         bytes memory data = abi.encode(
             tokenId,

--- a/contracts/SignatureVerification.sol
+++ b/contracts/SignatureVerification.sol
@@ -179,4 +179,13 @@ contract SignatureVerification is EIP712 {
     function getNonce(uint256 tokenId) external view onlyTokenOwner(tokenId) returns (uint256) {
         return uint256(_tokenAuth[tokenId].nonce);
     }
+    
+    /**
+     * @dev Internal function to get the current active key for a Lockbox.
+     * @param tokenId The ID of the Lockbox.
+     * @return The currently active Lockbox public key.
+     */
+    function _getActiveLockboxPublicKey(uint256 tokenId) internal view returns (address) {
+        return _tokenAuth[tokenId].activeLockboxPublicKey;
+    }
 }


### PR DESCRIPTION
- Add internal _getActiveLockboxPublicKey() getter function to SignatureVerification contract
- Add DuplicateKey error and validation check in rotateLockboxKey() to prevent duplicate key rotations