### PR TITLE
PR#9:L-06: Store and verify referenceId

### DIFF
--- a/contracts/Deposits.sol
+++ b/contracts/Deposits.sol
@@ -86,6 +86,7 @@ abstract contract Deposits is SignatureVerification, IERC721Receiver, Reentrancy
     function depositETH(uint256 tokenId, bytes32 referenceId) external payable nonReentrant {
         _requireOwnsLockbox(tokenId);
         if (msg.value == 0) revert ZeroAmount();
+        _verifyReferenceId(tokenId, referenceId);
 
         _ethBalances[tokenId] += msg.value;
         emit Deposited(tokenId, referenceId);
@@ -112,6 +113,7 @@ abstract contract Deposits is SignatureVerification, IERC721Receiver, Reentrancy
         _requireOwnsLockbox(tokenId);
         if (tokenAddress == address(0)) revert ZeroAddress();
         if (amount == 0) revert ZeroAmount();
+        _verifyReferenceId(tokenId, referenceId);
 
         _depositERC20(tokenId, tokenAddress, amount);
         emit Deposited(tokenId, referenceId);
@@ -136,6 +138,7 @@ abstract contract Deposits is SignatureVerification, IERC721Receiver, Reentrancy
     ) external nonReentrant {
         _requireOwnsLockbox(tokenId);
         if (nftContract == address(0)) revert ZeroAddress();
+        _verifyReferenceId(tokenId, referenceId);
 
         _depositERC721(tokenId, nftContract, nftTokenId);
         emit Deposited(tokenId, referenceId);
@@ -176,6 +179,7 @@ abstract contract Deposits is SignatureVerification, IERC721Receiver, Reentrancy
             tokenAddresses.length != tokenAmounts.length ||
             nftContracts.length != nftTokenIds.length
         ) revert MismatchedInputs();
+        _verifyReferenceId(tokenId, referenceId);
 
         _batchDeposit(tokenId, amountETH, tokenAddresses, tokenAmounts, nftContracts, nftTokenIds);
         emit Deposited(tokenId, referenceId);

--- a/contracts/Lockx.sol
+++ b/contracts/Lockx.sol
@@ -92,7 +92,7 @@ contract Lockx is ERC721, Ownable, Withdrawals, IERC5192 {
 
         // 2) Effects
         uint256 tokenId = _nextId++;
-        initialize(tokenId, lockboxPublicKey);
+        initialize(tokenId, lockboxPublicKey, referenceId);
         _mint(to, tokenId);
 
         // 3) Interactions
@@ -130,7 +130,7 @@ contract Lockx is ERC721, Ownable, Withdrawals, IERC5192 {
 
         // 2) Effects
         uint256 tokenId = _nextId++;
-        initialize(tokenId, lockboxPublicKey);
+        initialize(tokenId, lockboxPublicKey, referenceId);
         _mint(to, tokenId);
         
         // 3) Interactions
@@ -165,7 +165,7 @@ contract Lockx is ERC721, Ownable, Withdrawals, IERC5192 {
 
         // 2) Effects
         uint256 tokenId = _nextId++;
-        initialize(tokenId, lockboxPublicKey);
+        initialize(tokenId, lockboxPublicKey, referenceId);
         _mint(to, tokenId);
         
         // 3) Interactions
@@ -213,7 +213,7 @@ contract Lockx is ERC721, Ownable, Withdrawals, IERC5192 {
 
         // 2) Effects
         uint256 tokenId = _nextId++;
-        initialize(tokenId, lockboxPublicKey);
+        initialize(tokenId, lockboxPublicKey, referenceId);
         _mint(to, tokenId);
         
         // 3) Interactions
@@ -267,6 +267,7 @@ contract Lockx is ERC721, Ownable, Withdrawals, IERC5192 {
         if (_ownerOf(tokenId) == address(0)) revert NonexistentToken();
         if (ownerOf(tokenId) != msg.sender) revert NotOwner();
         if (block.timestamp > signatureExpiry) revert SignatureExpired();
+        _verifyReferenceId(tokenId, referenceId);
 
         bytes memory data = abi.encode(
             tokenId,
@@ -333,6 +334,7 @@ contract Lockx is ERC721, Ownable, Withdrawals, IERC5192 {
     ) external nonReentrant {
         _requireOwnsLockbox(tokenId);
         if (block.timestamp > signatureExpiry) revert SignatureExpired();
+        _verifyReferenceId(tokenId, referenceId);
 
         bytes memory data = abi.encode(
             tokenId,
@@ -380,6 +382,7 @@ contract Lockx is ERC721, Ownable, Withdrawals, IERC5192 {
     ) external nonReentrant {
         _requireOwnsLockbox(tokenId);
         if (block.timestamp > signatureExpiry) revert SignatureExpired();
+        _verifyReferenceId(tokenId, referenceId);
 
         bytes memory data = abi.encode(tokenId, referenceId, msg.sender, signatureExpiry);
         verifySignature(

--- a/contracts/SignatureVerification.sol
+++ b/contracts/SignatureVerification.sol
@@ -42,6 +42,7 @@ contract SignatureVerification is EIP712 {
     struct TokenAuth {
         address activeLockboxPublicKey;
         uint96 nonce;
+        bytes32 referenceId;
     }
 
     /// @dev Mapping from Lockbox token ID to its TokenAuth.
@@ -54,6 +55,7 @@ contract SignatureVerification is EIP712 {
     error InvalidSignature();
     error AlreadyInitialized();
     error ZeroKey();
+    error InvalidReferenceId();
 
 
     /* ─────────────────── EIP-712 setup ───────────────────── */
@@ -74,18 +76,20 @@ contract SignatureVerification is EIP712 {
     }
 
     /**
-     * @notice Initializes the Lockbox data with a public key and nonce.
+     * @notice Initializes the Lockbox data with a public key, nonce, and referenceId.
      * @dev Intended to be called once upon minting a new Lockbox.
      * @param tokenId The ID of the Lockbox being initialized.
      * @param lockboxPublicKey The public key that will sign operations for this Lockbox.
+     * @param referenceId The off-chain tracking identifier for this Lockbox.
      */
-    function initialize(uint256 tokenId, address lockboxPublicKey) internal {
+    function initialize(uint256 tokenId, address lockboxPublicKey, bytes32 referenceId) internal {
         if (_tokenAuth[tokenId].activeLockboxPublicKey != address(0)) {
             revert AlreadyInitialized();
         }
 
         _tokenAuth[tokenId].activeLockboxPublicKey = lockboxPublicKey;
         _tokenAuth[tokenId].nonce = 1;
+        _tokenAuth[tokenId].referenceId = referenceId;
     }
 
     /**
@@ -178,5 +182,25 @@ contract SignatureVerification is EIP712 {
      */
     function getNonce(uint256 tokenId) external view onlyTokenOwner(tokenId) returns (uint256) {
         return uint256(_tokenAuth[tokenId].nonce);
+    }
+    
+    /**
+     * @dev Internal function to verify that the provided referenceId matches the stored one.
+     * @param tokenId The ID of the Lockbox.
+     * @param referenceId The referenceId to verify.
+     */
+    function _verifyReferenceId(uint256 tokenId, bytes32 referenceId) internal view {
+        if (_tokenAuth[tokenId].referenceId != referenceId) {
+            revert InvalidReferenceId();
+        }
+    }
+    
+    /**
+     * @dev Internal function to get the stored referenceId for a Lockbox.
+     * @param tokenId The ID of the Lockbox.
+     * @return The stored referenceId.
+     */
+    function _getReferenceId(uint256 tokenId) internal view returns (bytes32) {
+        return _tokenAuth[tokenId].referenceId;
     }
 }

--- a/contracts/Withdrawals.sol
+++ b/contracts/Withdrawals.sol
@@ -82,6 +82,7 @@ abstract contract Withdrawals is Deposits {
         _requireOwnsLockbox(tokenId);
         if (recipient == address(0)) revert ZeroAddress();
         if (block.timestamp > signatureExpiry) revert SignatureExpired();
+        _verifyReferenceId(tokenId, referenceId);
 
         // 1) Verify
         bytes memory data = abi.encode(
@@ -143,6 +144,7 @@ abstract contract Withdrawals is Deposits {
         _requireOwnsLockbox(tokenId);
         if (recipient == address(0)) revert ZeroAddress();
         if (block.timestamp > signatureExpiry) revert SignatureExpired();
+        _verifyReferenceId(tokenId, referenceId);
 
         // 1) Verify
         bytes memory data = abi.encode(
@@ -215,6 +217,7 @@ abstract contract Withdrawals is Deposits {
         if (recipient == address(0)) revert ZeroAddress();
         if (recipient == address(this)) revert InvalidRecipient();
         if (block.timestamp > signatureExpiry) revert SignatureExpired();
+        _verifyReferenceId(tokenId, referenceId);
 
         // 1) Verify
         bytes memory data = abi.encode(
@@ -290,6 +293,7 @@ abstract contract Withdrawals is Deposits {
             tokenAddresses.length != tokenAmounts.length ||
             nftContracts.length != nftTokenIds.length
         ) revert MismatchedInputs();
+        _verifyReferenceId(tokenId, referenceId);
 
         // 1) Verify
         bytes memory data = abi.encode(
@@ -424,6 +428,7 @@ abstract contract Withdrawals is Deposits {
         if (!_isAllowedRouter(target)) {
             revert UnauthorizedRouter();
         }
+        _verifyReferenceId(tokenId, referenceId);
 
         // 1) Verify signature
         bytes memory authData = abi.encode(


### PR DESCRIPTION
- Add referenceId to TokenAuth struct for permanent storage per token during initialization
- Add InvalidReferenceId error and _verifyReferenceId() validation function
- Add referenceId verification to all deposit, withdrawal, and signature verified functions