### PR TITLE
PR#17:N-08: remove unnecessary parameters

### DIFF
--- a/contracts/Deposits.sol
+++ b/contracts/Deposits.sol
@@ -31,7 +31,6 @@ abstract contract Deposits is SignatureVerification, IERC721Receiver, Reentrancy
     error ZeroAddress();
     error ZeroAmount();
     error MismatchedInputs();
-    error ETHMismatch();
 
 
     /* ───────── Storage ───────── */
@@ -144,7 +143,6 @@ abstract contract Deposits is SignatureVerification, IERC721Receiver, Reentrancy
     /*
      * @notice Batch-deposit ETH, multiple ERC-20s, and multiple ERC-721s.
      * @param tokenId           The ID of the Lockbox.
-     * @param amountETH         ETH amount (`msg.value` must match).
      * @param tokenAddresses    ERC-20 token addresses to deposit.
      * @param tokenAmounts      Corresponding ERC-20 amounts.
      * @param nftContracts      ERC-721 contract addresses to deposit.
@@ -153,31 +151,28 @@ abstract contract Deposits is SignatureVerification, IERC721Receiver, Reentrancy
      *
      * Requirements:
      * - Caller must own the Lockbox.
-     * - At least one asset type must be deposited (ETH, ERC-20, or ERC-721).
-     * - `msg.value` must equal `amountETH`.
+     * - At least one asset type must be deposited (ETH via msg.value, ERC-20, or ERC-721).
      * - `tokenAddresses` and `tokenAmounts` arrays must have equal length.
      * - `nftContracts` and `nftTokenIds` arrays must have equal length.
      */
     function batchDeposit(
         uint256 tokenId,
-        uint256 amountETH,
         address[] calldata tokenAddresses,
         uint256[] calldata tokenAmounts,
         address[] calldata nftContracts,
         uint256[] calldata nftTokenIds,
         bytes32 referenceId
     ) external payable nonReentrant {
-        if (amountETH == 0 && tokenAddresses.length == 0 && nftContracts.length == 0)
+        if (msg.value == 0 && tokenAddresses.length == 0 && nftContracts.length == 0)
             revert ZeroAmount();
 
         _requireOwnsLockbox(tokenId);
-        if (msg.value != amountETH) revert ETHMismatch();
         if (
             tokenAddresses.length != tokenAmounts.length ||
             nftContracts.length != nftTokenIds.length
         ) revert MismatchedInputs();
 
-        _batchDeposit(tokenId, amountETH, tokenAddresses, tokenAmounts, nftContracts, nftTokenIds);
+        _batchDeposit(tokenId, msg.value, tokenAddresses, tokenAmounts, nftContracts, nftTokenIds);
         emit Deposited(tokenId, referenceId);
     }
 

--- a/contracts/Withdrawals.sol
+++ b/contracts/Withdrawals.sol
@@ -57,7 +57,6 @@ abstract contract Withdrawals is Deposits {
     /*
      * @notice Withdraw ETH from a Lockbox, authorized via EIP-712 signature.
      * @param tokenId         The ID of the Lockbox.
-     * @param messageHash     The EIP-712 digest that was signed.
      * @param signature       The EIP-712 signature by the active Lockbox key.
      * @param amountETH       The amount of ETH to withdraw.
      * @param recipient       The address receiving the ETH.
@@ -72,7 +71,6 @@ abstract contract Withdrawals is Deposits {
      */
     function withdrawETH(
         uint256 tokenId,
-        bytes32 messageHash,
         bytes memory signature,
         uint256 amountETH,
         address recipient,
@@ -94,7 +92,6 @@ abstract contract Withdrawals is Deposits {
         );
         verifySignature(
             tokenId,
-            messageHash,
             signature,
             address(0),
             OperationType.WITHDRAW_ETH,
@@ -116,7 +113,6 @@ abstract contract Withdrawals is Deposits {
     /*
      * @notice Withdraw an ERC-20 token from a Lockbox, authorized via EIP-712 signature.
      * @param tokenId         The ID of the Lockbox.
-     * @param messageHash     The EIP-712 digest that was signed.
      * @param signature       The EIP-712 signature by the active Lockbox key.
      * @param tokenAddress    The ERC-20 token address to withdraw.
      * @param amount          The amount of tokens to withdraw.
@@ -132,7 +128,6 @@ abstract contract Withdrawals is Deposits {
      */
     function withdrawERC20(
         uint256 tokenId,
-        bytes32 messageHash,
         bytes memory signature,
         address tokenAddress,
         uint256 amount,
@@ -156,7 +151,6 @@ abstract contract Withdrawals is Deposits {
         );
         verifySignature(
             tokenId,
-            messageHash,
             signature,
             address(0),
             OperationType.WITHDRAW_ERC20,
@@ -187,7 +181,6 @@ abstract contract Withdrawals is Deposits {
     /*
      * @notice Withdraw an ERC-721 token from a Lockbox, authorized via EIP-712 signature.
      * @param tokenId         The ID of the Lockbox.
-     * @param messageHash     The EIP-712 digest that was signed.
      * @param signature       The EIP-712 signature by the active Lockbox key.
      * @param nftContract     The ERC-721 contract address to withdraw.
      * @param nftTokenId      The token ID of the ERC-721 to withdraw.
@@ -203,7 +196,6 @@ abstract contract Withdrawals is Deposits {
      */
     function withdrawERC721(
         uint256 tokenId,
-        bytes32 messageHash,
         bytes memory signature,
         address nftContract,
         uint256 nftTokenId,
@@ -228,7 +220,6 @@ abstract contract Withdrawals is Deposits {
         );
         verifySignature(
             tokenId,
-            messageHash,
             signature,
             address(0),
             OperationType.WITHDRAW_NFT,
@@ -251,7 +242,6 @@ abstract contract Withdrawals is Deposits {
     /*
      * @notice Batch withdrawal of ETH, ERC-20s, and ERC-721s with a single signature.
      * @param tokenId         The ID of the Lockbox.
-     * @param messageHash     The EIP-712 digest that was signed.
      * @param signature       The EIP-712 signature by the active Lockbox key.
      * @param amountETH       The amount of ETH to withdraw.
      * @param tokenAddresses  The list of ERC-20 token addresses to withdraw.
@@ -272,7 +262,6 @@ abstract contract Withdrawals is Deposits {
      */
     function batchWithdraw(
         uint256 tokenId,
-        bytes32 messageHash,
         bytes memory signature,
         uint256 amountETH,
         address[] calldata tokenAddresses,
@@ -306,7 +295,6 @@ abstract contract Withdrawals is Deposits {
         );
         verifySignature(
             tokenId,
-            messageHash,
             signature,
             address(0),
             OperationType.BATCH_WITHDRAW,
@@ -380,7 +368,6 @@ abstract contract Withdrawals is Deposits {
     /*
      * @notice Execute an asset swap within a Lockbox, authorized via EIP-712 signature.
      * @param tokenId         The ID of the Lockbox.
-     * @param messageHash     The EIP-712 digest that was signed.
      * @param signature       The EIP-712 signature by the active Lockbox key.
      * @param tokenIn         The input token address (address(0) for ETH).
      * @param tokenOut        The output token address (address(0) for ETH).
@@ -402,7 +389,6 @@ abstract contract Withdrawals is Deposits {
      */
     function swapInLockbox(
         uint256 tokenId,
-        bytes32 messageHash,
         bytes memory signature,
         address tokenIn,
         address tokenOut,
@@ -441,7 +427,6 @@ abstract contract Withdrawals is Deposits {
         );
         verifySignature(
             tokenId,
-            messageHash,
             signature,
             address(0),
             OperationType.SWAP_ASSETS,


### PR DESCRIPTION
- Remove 'to' parameter from createLockbox functions
- Remove 'amountETH' parameter from createLockboxWithBatch and batchDeposit
- Remove 'messageHash' parameter from verifySignature and all calling functions
- Remove 'dataHash' local variable and compute hash inline
- Remove unused errors: InvalidMessageHash, ETHMismatch