### PR TITLE
PR#21:N-12: Adopt consistent naming convention for internal functions

### DIFF
--- a/contracts/Lockx.sol
+++ b/contracts/Lockx.sol
@@ -92,7 +92,7 @@ contract Lockx is ERC721, Ownable, Withdrawals, IERC5192 {
 
         // 2) Effects
         uint256 tokenId = _nextId++;
-        initialize(tokenId, lockboxPublicKey);
+        _initialize(tokenId, lockboxPublicKey);
         _mint(to, tokenId);
 
         // 3) Interactions
@@ -130,7 +130,7 @@ contract Lockx is ERC721, Ownable, Withdrawals, IERC5192 {
 
         // 2) Effects
         uint256 tokenId = _nextId++;
-        initialize(tokenId, lockboxPublicKey);
+        _initialize(tokenId, lockboxPublicKey);
         _mint(to, tokenId);
         
         // 3) Interactions
@@ -165,7 +165,7 @@ contract Lockx is ERC721, Ownable, Withdrawals, IERC5192 {
 
         // 2) Effects
         uint256 tokenId = _nextId++;
-        initialize(tokenId, lockboxPublicKey);
+        _initialize(tokenId, lockboxPublicKey);
         _mint(to, tokenId);
         
         // 3) Interactions
@@ -213,7 +213,7 @@ contract Lockx is ERC721, Ownable, Withdrawals, IERC5192 {
 
         // 2) Effects
         uint256 tokenId = _nextId++;
-        initialize(tokenId, lockboxPublicKey);
+        _initialize(tokenId, lockboxPublicKey);
         _mint(to, tokenId);
         
         // 3) Interactions
@@ -275,7 +275,7 @@ contract Lockx is ERC721, Ownable, Withdrawals, IERC5192 {
             msg.sender,
             signatureExpiry
         );
-        verifySignature(
+        _verifySignature(
             tokenId,
             messageHash,
             signature,
@@ -341,7 +341,7 @@ contract Lockx is ERC721, Ownable, Withdrawals, IERC5192 {
             msg.sender,
             signatureExpiry
         );
-        verifySignature(
+        _verifySignature(
             tokenId,
             messageHash,
             signature,
@@ -382,7 +382,7 @@ contract Lockx is ERC721, Ownable, Withdrawals, IERC5192 {
         if (block.timestamp > signatureExpiry) revert SignatureExpired();
 
         bytes memory data = abi.encode(tokenId, referenceId, msg.sender, signatureExpiry);
-        verifySignature(
+        _verifySignature(
             tokenId,
             messageHash,
             signature,

--- a/contracts/SignatureVerification.sol
+++ b/contracts/SignatureVerification.sol
@@ -79,7 +79,7 @@ contract SignatureVerification is EIP712 {
      * @param tokenId The ID of the Lockbox being initialized.
      * @param lockboxPublicKey The public key that will sign operations for this Lockbox.
      */
-    function initialize(uint256 tokenId, address lockboxPublicKey) internal {
+    function _initialize(uint256 tokenId, address lockboxPublicKey) internal {
         if (_tokenAuth[tokenId].activeLockboxPublicKey != address(0)) {
             revert AlreadyInitialized();
         }
@@ -112,7 +112,7 @@ contract SignatureVerification is EIP712 {
      * - On successful verification, the nonce increments.
      * - If `opType` is `ROTATE_KEY`, the Lockbox public key is updated to `newLockboxPublicKey`.
      */
-    function verifySignature(
+    function _verifySignature(
         uint256 tokenId,
         bytes32 messageHash,
         bytes memory signature,

--- a/contracts/Withdrawals.sol
+++ b/contracts/Withdrawals.sol
@@ -92,7 +92,7 @@ abstract contract Withdrawals is Deposits {
             msg.sender,
             signatureExpiry
         );
-        verifySignature(
+        _verifySignature(
             tokenId,
             messageHash,
             signature,
@@ -154,7 +154,7 @@ abstract contract Withdrawals is Deposits {
             msg.sender,
             signatureExpiry
         );
-        verifySignature(
+        _verifySignature(
             tokenId,
             messageHash,
             signature,
@@ -226,7 +226,7 @@ abstract contract Withdrawals is Deposits {
             msg.sender,
             signatureExpiry
         );
-        verifySignature(
+        _verifySignature(
             tokenId,
             messageHash,
             signature,
@@ -304,7 +304,7 @@ abstract contract Withdrawals is Deposits {
             msg.sender,
             signatureExpiry
         );
-        verifySignature(
+        _verifySignature(
             tokenId,
             messageHash,
             signature,
@@ -439,7 +439,7 @@ abstract contract Withdrawals is Deposits {
             signatureExpiry,
             recipient
         );
-        verifySignature(
+        _verifySignature(
             tokenId,
             messageHash,
             signature,


### PR DESCRIPTION
- Rename initialize() to _initialize()
- Rename verifySignature() to _verifySignature()
- Update function calls to reference new naming convention