### PR TITLE
PR#22:N-13: Fix inconsistent indexing across the codebase

### DIFF
--- a/contracts/Deposits.sol
+++ b/contracts/Deposits.sol
@@ -203,10 +203,10 @@ abstract contract Deposits is SignatureVerification, IERC721Receiver, Reentrancy
         uint256 received = t.balanceOf(address(this)) - before;
         if (received == 0) revert ZeroAmount();
 
-        // Register new token with index
-        if (_erc20Index[tokenId][token] == 0) {
-            _erc20Index[tokenId][token] = _erc20TokenAddresses[tokenId].length + 1;
+        // Register new token
+        if (_erc20Balances[tokenId][token] == 0) {
             _erc20TokenAddresses[tokenId].push(token);
+            _erc20Index[tokenId][token] = _erc20TokenAddresses[tokenId].length - 1;
         }
 
         _erc20Balances[tokenId][token] += received;
@@ -219,10 +219,10 @@ abstract contract Deposits is SignatureVerification, IERC721Receiver, Reentrancy
         // nftContract is already validated in the public functions before calling this
         bytes32 key = keccak256(abi.encodePacked(nftContract, nftTokenId));
 
-        // Check if NFT is new by seeing if nftContract is zero
+        // Register new NFT key
         if (_lockboxNftData[tokenId][key].nftContract == address(0)) {
-            _nftIndex[tokenId][key] = _nftKeys[tokenId].length + 1;
             _nftKeys[tokenId].push(key);
+            _nftIndex[tokenId][key] = _nftKeys[tokenId].length - 1;
         }
         _lockboxNftData[tokenId][key] = nftBalances(nftContract, nftTokenId);
 
@@ -266,14 +266,18 @@ abstract contract Deposits is SignatureVerification, IERC721Receiver, Reentrancy
      * @dev Remove an ERC-20 token address from the tracking array.
      */
     function _removeERC20Token(uint256 tokenId, address token) internal {
-        uint256 idx = _erc20Index[tokenId][token];
-        if (idx == 0) return;
-
         uint256 arrayLength = _erc20TokenAddresses[tokenId].length;
-        if (idx != arrayLength) {
-            address lastToken = _erc20TokenAddresses[tokenId][arrayLength - 1];
-            _erc20TokenAddresses[tokenId][idx - 1] = lastToken;
-            _erc20Index[tokenId][lastToken] = idx;
+        if (arrayLength == 0) return;
+
+        uint256 index = _erc20Index[tokenId][token];
+        if (index >= arrayLength) return;
+        if (_erc20TokenAddresses[tokenId][index] != token) return;
+
+        uint256 lastIndex = arrayLength - 1;
+        if (index != lastIndex) {
+            address lastToken = _erc20TokenAddresses[tokenId][lastIndex];
+            _erc20TokenAddresses[tokenId][index] = lastToken;
+            _erc20Index[tokenId][lastToken] = index;
         }
         _erc20TokenAddresses[tokenId].pop();
         delete _erc20Index[tokenId][token];
@@ -283,14 +287,18 @@ abstract contract Deposits is SignatureVerification, IERC721Receiver, Reentrancy
      * @dev Remove an ERC-721 key from the tracking array.
      */
     function _removeNFTKey(uint256 tokenId, bytes32 key) internal {
-        uint256 idx = _nftIndex[tokenId][key];
-        if (idx == 0) return;
-        
         uint256 arrayLength = _nftKeys[tokenId].length;
-        if (idx != arrayLength) {
-            bytes32 lastKey = _nftKeys[tokenId][arrayLength - 1];
-            _nftKeys[tokenId][idx - 1] = lastKey;
-            _nftIndex[tokenId][lastKey] = idx;
+        if (arrayLength == 0) return;
+
+        uint256 index = _nftIndex[tokenId][key];
+        if (index >= arrayLength) return;
+        if (_nftKeys[tokenId][index] != key) return;
+
+        uint256 lastIndex = arrayLength - 1;
+        if (index != lastIndex) {
+            bytes32 lastKey = _nftKeys[tokenId][lastIndex];
+            _nftKeys[tokenId][index] = lastKey;
+            _nftIndex[tokenId][lastKey] = index;
         }
         _nftKeys[tokenId].pop();
         delete _nftIndex[tokenId][key];

--- a/contracts/SignatureVerification.sol
+++ b/contracts/SignatureVerification.sol
@@ -85,7 +85,7 @@ contract SignatureVerification is EIP712 {
         }
 
         _tokenAuth[tokenId].activeLockboxPublicKey = lockboxPublicKey;
-        _tokenAuth[tokenId].nonce = 1;
+        _tokenAuth[tokenId].nonce = 0;
     }
 
     /**

--- a/contracts/Withdrawals.sol
+++ b/contracts/Withdrawals.sol
@@ -535,9 +535,9 @@ abstract contract Withdrawals is Deposits {
                 _ethBalances[TREASURY_LOCKBOX_ID] += feeAmount;
             } else {
                 // Register token if new for treasury
-                if (_erc20Index[TREASURY_LOCKBOX_ID][tokenOut] == 0) {
-                    _erc20Index[TREASURY_LOCKBOX_ID][tokenOut] = _erc20TokenAddresses[TREASURY_LOCKBOX_ID].length + 1;
+                if (_erc20Balances[TREASURY_LOCKBOX_ID][tokenOut] == 0) {
                     _erc20TokenAddresses[TREASURY_LOCKBOX_ID].push(tokenOut);
+                    _erc20Index[TREASURY_LOCKBOX_ID][tokenOut] = _erc20TokenAddresses[TREASURY_LOCKBOX_ID].length - 1;
                 }
                 _erc20Balances[TREASURY_LOCKBOX_ID][tokenOut] += feeAmount;
             }
@@ -557,10 +557,10 @@ abstract contract Withdrawals is Deposits {
             if (tokenOut == address(0)) {
                 _ethBalances[tokenId] += userAmount;
             } else {
-                // Register token if new for user
-                if (_erc20Index[tokenId][tokenOut] == 0) {
-                    _erc20Index[tokenId][tokenOut] = _erc20TokenAddresses[tokenId].length + 1;
+                // Register token if new for user (presence derived from balance)
+                if (_erc20Balances[tokenId][tokenOut] == 0) {
                     _erc20TokenAddresses[tokenId].push(tokenOut);
+                    _erc20Index[tokenId][tokenOut] = _erc20TokenAddresses[tokenId].length - 1;
                 }
                 _erc20Balances[tokenId][tokenOut] += userAmount;
             }
@@ -625,10 +625,10 @@ abstract contract Withdrawals is Deposits {
             }
         }
         nftContracts = new nftBalances[](count);
-        uint256 idx;
+        uint256 index;
         for (uint256 i; i < nftList.length; ) {
             if (_lockboxNftData[tokenId][nftList[i]].nftContract != address(0)) {
-                nftContracts[idx++] = _lockboxNftData[tokenId][nftList[i]];
+                nftContracts[index++] = _lockboxNftData[tokenId][nftList[i]];
             }
             unchecked {
                 ++i;


### PR DESCRIPTION
- Standardized ERC20 and NFT tracking arrays to use 0-based indexing instead of 1-based
- Changed from index-based checks to balance-based checks for determining if tokens are already tracked
- Updated token indexing logic in swapInLockbox for treasury fee collection
- Added proper bounds checking and validation in _removeERC20Token and _removeNFTKey functions